### PR TITLE
drv-iio-compass: Change the compass channel name

### DIFF
--- a/src/drv-iio-buffer-compass.c
+++ b/src/drv-iio-buffer-compass.c
@@ -33,6 +33,7 @@ process_scan (IIOSensorData data, DrvData *or_data)
 {
 	int i;
 	int raw_heading;
+	char* channel_name = "in_rot_from_north_magnetic_tilt_comp";
 	gdouble scale;
 	gboolean present_level;
 	CompassReadings readings;
@@ -51,7 +52,7 @@ process_scan (IIOSensorData data, DrvData *or_data)
 		return 0;
 	}
 
-	process_scan_1 (data.data + or_data->buffer_data->scan_size*i, or_data->buffer_data, "in_rot_from_north_magnetic_tilt_comp_raw", &raw_heading, &scale, &present_level);
+	process_scan_1 (data.data + or_data->buffer_data->scan_size*i, or_data->buffer_data, channel_name, &raw_heading, &scale, &present_level);
 
 	readings.heading = raw_heading * scale;
 	g_debug ("Read from IIO: %f (%d times %f scale)", readings.heading, raw_heading, scale);

--- a/src/iio-buffer-utils.c
+++ b/src/iio-buffer-utils.c
@@ -501,6 +501,9 @@ process_scan_1 (char              *data,
 			break;
 		}
 	}
+	if (!*ch_present) {
+		g_warning ("IIO channel '%s' could not be found", ch_name);
+	}
 }
 
 /**


### PR DESCRIPTION
The channel name should not include _raw as the name will not include this. This fixes an issue where the compass would not return any data on a Surface Pro 2.