### PR TITLE
Remove a gfree call done from an object now "owning" the mem

### DIFF
--- a/src/drv-iio-buffer-compass.c
+++ b/src/drv-iio-buffer-compass.c
@@ -95,29 +95,35 @@ bail:
 	g_free(data.data);
 }
 
-static char *
+static const gchar *
 get_trigger_name (GUdevDevice *device)
 {
 	GList *devices, *l;
 	GUdevClient *client;
 	gboolean has_trigger = FALSE;
-	char *trigger_name;
+	char *trigger_name_magntd;
+	const gchar * device_name;
+	const gchar * trigger_name;
 	const gchar * const subsystems[] = { "iio", NULL };
 
 	client = g_udev_client_new (subsystems);
 	devices = g_udev_client_query_by_subsystem (client, "iio");
 
 	/* Find the associated trigger */
-	trigger_name = g_strdup_printf ("magn_3d-dev%s", g_udev_device_get_number (device));
+	trigger_name_magntd = g_strdup_printf ("magn_3d-dev%s", g_udev_device_get_number (device));
 	for (l = devices; l != NULL; l = l->next) {
 		GUdevDevice *dev = l->data;
 
-		if (g_strcmp0 (trigger_name, g_udev_device_get_sysfs_attr (dev, "name")) == 0) {
+		device_name = g_udev_device_get_sysfs_attr (dev, "name");
+		if (g_strcmp0 (trigger_name_magntd, device_name) == 0) {
+
 			g_debug ("Found associated trigger at %s", g_udev_device_get_sysfs_path (dev));
 			has_trigger = TRUE;
+			trigger_name = g_strdup (device_name);
 			break;
 		}
 	}
+	g_free (trigger_name_magntd);
 
 	g_list_free_full (devices, g_object_unref);
 	g_clear_object (&client);
@@ -127,7 +133,6 @@ get_trigger_name (GUdevDevice *device)
 
 	g_warning ("Could not find trigger name associated with %s",
 		   g_udev_device_get_sysfs_path (device));
-	g_free (trigger_name);
 	return NULL;
 }
 
@@ -159,7 +164,7 @@ iio_buffer_compass_open (GUdevDevice        *device,
                          ReadingsUpdateFunc  callback_func,
                          gpointer            user_data)
 {
-	char *trigger_name;
+	const gchar *trigger_name;
 
 	drv_data = g_new0 (DrvData, 1);
 
@@ -170,7 +175,6 @@ iio_buffer_compass_open (GUdevDevice        *device,
 		return FALSE;
 	}
 	drv_data->buffer_data = buffer_drv_data_new (device, trigger_name);
-	g_free (trigger_name);
 
 	if (!drv_data->buffer_data) {
 		g_clear_pointer (&drv_data, g_free);

--- a/src/drv-iio-buffer-light.c
+++ b/src/drv-iio-buffer-light.c
@@ -102,29 +102,34 @@ bail:
 	g_free(data.data);
 }
 
-static char *
+static const gchar *
 get_trigger_name (GUdevDevice *device)
 {
 	GList *devices, *l;
 	GUdevClient *client;
 	gboolean has_trigger = FALSE;
-	char *trigger_name;
+	char *trigger_name_als;
+	const gchar * device_name;
+	const gchar * trigger_name;
 	const gchar * const subsystems[] = { "iio", NULL };
 
 	client = g_udev_client_new (subsystems);
 	devices = g_udev_client_query_by_subsystem (client, "iio");
 
 	/* Find the associated trigger */
-	trigger_name = g_strdup_printf ("als-dev%s", g_udev_device_get_number (device));
+	trigger_name_als = g_strdup_printf ("als-dev%s", g_udev_device_get_number (device));
 	for (l = devices; l != NULL; l = l->next) {
 		GUdevDevice *dev = l->data;
 
-		if (g_strcmp0 (trigger_name, g_udev_device_get_sysfs_attr (dev, "name")) == 0) {
+		device_name = g_udev_device_get_sysfs_attr (dev, "name");
+		if (g_strcmp0 (trigger_name_als, device_name) == 0) {
 			g_debug ("Found associated trigger at %s", g_udev_device_get_sysfs_path (dev));
 			has_trigger = TRUE;
+			trigger_name = g_strdup (device_name);
 			break;
 		}
 	}
+	g_free (trigger_name_als);
 
 	g_list_free_full (devices, g_object_unref);
 	g_clear_object (&client);
@@ -134,7 +139,6 @@ get_trigger_name (GUdevDevice *device)
 
 	g_warning ("Could not find trigger name associated with %s",
 		   g_udev_device_get_sysfs_path (device));
-	g_free (trigger_name);
 	return NULL;
 }
 
@@ -185,7 +189,7 @@ iio_buffer_light_open (GUdevDevice        *device,
                        ReadingsUpdateFunc  callback_func,
                        gpointer            user_data)
 {
-	char *trigger_name;
+	const gchar *trigger_name;
 
 	drv_data = g_new0 (DrvData, 1);
 
@@ -196,7 +200,6 @@ iio_buffer_light_open (GUdevDevice        *device,
 		return FALSE;
 	}
 	drv_data->buffer_data = buffer_drv_data_new (device, trigger_name);
-	g_free (trigger_name);
 
 	if (!drv_data->buffer_data) {
 		g_clear_pointer (&drv_data, g_free);

--- a/src/iio-buffer-utils.c
+++ b/src/iio-buffer-utils.c
@@ -630,8 +630,6 @@ buffer_drv_data_free (BufferDrvData *buffer_data)
 
 	disable_ring_buffer (buffer_data);
 
-	g_free (buffer_data->trigger_name);
-
 	for (i = 0; i < buffer_data->channels_count; i++)
 		channel_info_free (buffer_data->channels[i]);
 	g_free (buffer_data->channels);


### PR DESCRIPTION
A new char is created, gstrdupprintf, and is freed in multiple locations including from inside iiobufferutils.

As a solution we strdup a string from the sysfs attribute "name" and then never free it.  It's assumed that every device is discovered only once, a check for this device being previously discovered could be added.  The change from using the created char to the char from sysfs is to provide a means to have multiple created strings, a later patch for mpu6050 support.