### PR TITLE
Add 2 byte process support, used on mpu6050

### DIFF
--- a/src/iio-buffer-utils.c
+++ b/src/iio-buffer-utils.c
@@ -476,6 +476,26 @@ process_scan_1 (char              *data,
 
 		switch (buffer_data->channels[k]->bytes) {
 			/* only a few cases implemented so far */
+		case 2:
+			if (!buffer_data->channels[k]->is_signed) {
+				guint16 val = *(guint16 *) (data + buffer_data->channels[k]->location);
+				val = val >> buffer_data->channels[k]->shift;
+				if (buffer_data->channels[k]->bits_used < 16) val &= ((guint16) 1 << buffer_data->channels[k]->bits_used) - 1;
+				*ch_val = (int) val;
+				*ch_present = TRUE;
+			} else {
+				gint16 val = *(gint16 *) (data + buffer_data->channels[k]->location);
+				val = val >> buffer_data->channels[k]->shift;
+				if (buffer_data->channels[k]->bits_used < 16) val &= ((guint16) 1 << buffer_data->channels[k]->bits_used) - 1;
+				val = (gint16) (val << (16 - buffer_data->channels[k]->bits_used)) >> (16 - buffer_data->channels[k]->bits_used);
+				*ch_val = (int) val;
+				if (buffer_data->channels[k]->scale)
+					*ch_scale = buffer_data->channels[k]->scale;
+				else
+					*ch_scale = 1.0;
+				*ch_present = TRUE;
+			}
+			break;
 		case 4:
 			if (!buffer_data->channels[k]->is_signed) {
 				guint32 val = *(guint32 *) (data + buffer_data->channels[k]->location);
@@ -496,7 +516,6 @@ process_scan_1 (char              *data,
 				*ch_present = TRUE;
 			}
 			break;
-		case 2:
 		case 8:
 			g_error ("Process %d bytes channels not supported yet", buffer_data->channels[k]->bytes);
 		default:


### PR DESCRIPTION
A simple s/32/16/g is applied to the existing code for 4 byte processing.  This format is used by the mpu6050 device.  Not yet sure if the code works as intended, the device behaves erratic currently and this code is one possible cause.