### PR TITLE
fix screen orientation for i2c-SMO8500:00

### DIFF
--- a/src/drv-iio-poll-accel.c
+++ b/src/drv-iio-poll-accel.c
@@ -64,9 +64,9 @@ poll_orientation (gpointer user_data)
 	if (g_strcmp0 ("i2c-SMO8500:00", g_udev_device_get_sysfs_attr (data->dev, "name")) == 0) {
 		/* Quirk for i2c-SMO8500:00 device,
 		 * swap x and y */
-		readings.accel_x = accel_y;
-		readings.accel_y = accel_x;
-		readings.accel_z = accel_z;
+		readings.accel_x = accel_x;
+		readings.accel_y = -accel_y;
+		readings.accel_z = -accel_z;
 	} else {
 		readings.accel_x = accel_x;
 		readings.accel_y = accel_y;


### PR DESCRIPTION
Previously the screen orientation was always 90° off. Fix this by
tweaking the sensor values correctly.

Tested on Odys Wintab 8:
AXDIA International GmbH Wintab Gen 8/Type2 - Board Product Name,
BIOS AD890.1.02.022 09/25/2014

udevadm info --export-db
[...]
P: /devices/platform/80860F41:02/i2c-10/i2c-SMO8500:00/iio:device0
N: iio:device0
E: DEVNAME=/dev/iio:device0
E:
DEVPATH=/devices/platform/80860F41:02/i2c-10/i2c-SMO8500:00/iio:device0
E: DEVTYPE=iio_device
E: MAJOR=248
E: MINOR=0
E: SUBSYSTEM=iio
E: SYSTEMD_WANTS=iio-sensor-proxy.service
E: TAGS=:systemd:
E: USEC_INITIALIZED=10911453

Signed-off-by: Stefan Assmann <sassmann@kpanic.de>