### PR TITLE
Add support for HP EliteBook 8540w

### DIFF
--- a/src/drv-input-accel.c
+++ b/src/drv-input-accel.c
@@ -74,9 +74,18 @@ accelerometer_changed (void)
 
 	close (fd);
 
-	readings.accel_x = accel_x;
-	readings.accel_y = accel_y;
-	readings.accel_z = accel_z;
+	if (g_strcmp0 ("platform-lis3lv02d", g_udev_device_get_property (drv_data->dev, "ID_PATH")) == 0) {
+		/* Quirk for lis3lv02d device,
+		 * take opposite x */
+		readings.accel_x = -accel_x;
+		readings.accel_y = accel_y;
+		readings.accel_z = accel_z;
+	} else {
+		readings.accel_x = accel_x;
+		readings.accel_y = accel_y;
+		readings.accel_z = accel_z;
+	}
+
 	/* Scale from 1G ~= 256 to a value in m/s² */
 	readings.scale = 1.0 / 256 * 9.81;
 


### PR DESCRIPTION
This adds a quirk for the accelerometer lis3lv02d that
is used in the various HP laptops. More info here:
https://www.kernel.org/doc/Documentation/misc-devices/lis3lv02d

The accelerometer is an input device. The follwing is the
output of udevadm. ID_PATH seemed most useful to filter on.

P: /devices/platform/lis3lv02d/input/input13/event7
N: input/event7
S: input/by-path/platform-lis3lv02d-event
E: DEVLINKS=/dev/input/by-path/platform-lis3lv02d-event
E: DEVNAME=/dev/input/event7
E: DEVPATH=/devices/platform/lis3lv02d/input/input13/event7
E: ID_INPUT=1
E: ID_INPUT_ACCELEROMETER=1
E: ID_PATH=platform-lis3lv02d
E: ID_PATH_TAG=platform-lis3lv02d
E: LIBINPUT_DEVICE_GROUP=19/0/0/0:lis3lv02d
E: MAJOR=13
E: MINOR=71
E: SUBSYSTEM=input
E: SYSTEMD_WANTS=iio-sensor-proxy.service
E: TAGS=:systemd:
E: USEC_INITIALIZED=11548869