### PR TITLE
Prevent failure for non existing scale and offset attributes

### DIFF
--- a/src/iio-buffer-utils.c
+++ b/src/iio-buffer-utils.c
@@ -275,7 +275,7 @@ build_channel_array (const char        *device_dir,
 							device_dir,
 							current->name,
 							current->generic_name);
-			if (ret < 0)
+			if ((ret < 0) && (ret != -ENOENT))
 				goto error;
 
 			ret = iioutils_get_param_float (&current->offset,
@@ -283,7 +283,7 @@ build_channel_array (const char        *device_dir,
 							device_dir,
 							current->name,
 							current->generic_name);
-			if (ret < 0)
+			if ((ret < 0) && (ret != -ENOENT))
 				goto error;
 
 			ret = iioutils_get_type (&current->is_signed,


### PR DESCRIPTION
build_channel_array() goes through each directory member in
scan_elements folder and tries to get scale and offset of matching
elements. But there will be no scale and offset for some elements
like timestamp.
For example:
in_accel_x_en     in_accel_y_en     in_accel_z_en     in_timestamp_en
in_accel_x_index  in_accel_y_index  in_accel_z_index  in_timestamp_index
in_accel_x_type   in_accel_y_type   in_accel_z_type   in_timestamp_type

When scale and offset not present, iioutils_get_param_float() will fail,
this causes return from the build_channel_array().

It shouldn't return when error is caused when the attribute is not
present. Like in this case in_time_stamp_scale.
This is already fixed in iio_utils.c in linux source tree under
tools/iio, so adding the same change here.