### PR TITLE
Security fix: Make D-Bus policy rules only affect SensorProxy itself

### DIFF
--- a/data/net.hadess.SensorProxy.conf
+++ b/data/net.hadess.SensorProxy.conf
@@ -12,22 +12,22 @@
 
   <!-- Only Geoclue can access the compass -->
   <policy user="geoclue">
-    <allow send_interface="net.hadess.SensorProxy.Compass" send_path="/net/hadess/SensorProxy/Compass"/>
-    <allow send_interface="org.freedesktop.DBus.Introspectable" send_path="/net/hadess/SensorProxy/Compass"/>
-    <allow send_interface="org.freedesktop.DBus.Properties" send_path="/net/hadess/SensorProxy/Compass"/>
-    <allow send_interface="org.freedesktop.DBus.Peer" send_path="/net/hadess/SensorProxy/Compass"/>
+    <allow send_destination="net.hadess.SensorProxy" send_interface="net.hadess.SensorProxy.Compass" send_path="/net/hadess/SensorProxy/Compass"/>
+    <allow send_destination="net.hadess.SensorProxy" send_interface="org.freedesktop.DBus.Introspectable" send_path="/net/hadess/SensorProxy/Compass"/>
+    <allow send_destination="net.hadess.SensorProxy" send_interface="org.freedesktop.DBus.Properties" send_path="/net/hadess/SensorProxy/Compass"/>
+    <allow send_destination="net.hadess.SensorProxy" send_interface="org.freedesktop.DBus.Peer" send_path="/net/hadess/SensorProxy/Compass"/>
   </policy>
 
   <!-- Anyone can talk to the main interface -->
   <policy context="default">
-    <allow send_interface="net.hadess.SensorProxy"/>
-    <allow send_interface="org.freedesktop.DBus.Introspectable"/>
-    <allow send_interface="org.freedesktop.DBus.Properties"/>
-    <allow send_interface="org.freedesktop.DBus.Peer"/>
-    <deny send_interface="org.freedesktop.DBus.Introspectable" send_path="/net/hadess/SensorProxy/Compass"/>
-    <deny send_interface="org.freedesktop.DBus.Properties" send_path="/net/hadess/SensorProxy/Compass"/>
-    <deny send_interface="org.freedesktop.DBus.Peer" send_path="/net/hadess/SensorProxy/Compass"/>
-    <!-- <deny send_interface="net.hadess.SensorProxy.Compass"/> -->
+    <allow send_destination="net.hadess.SensorProxy" send_interface="net.hadess.SensorProxy"/>
+    <allow send_destination="net.hadess.SensorProxy" send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="net.hadess.SensorProxy" send_interface="org.freedesktop.DBus.Properties"/>
+    <allow send_destination="net.hadess.SensorProxy" send_interface="org.freedesktop.DBus.Peer"/>
+    <deny send_destination="net.hadess.SensorProxy" send_interface="org.freedesktop.DBus.Introspectable" send_path="/net/hadess/SensorProxy/Compass"/>
+    <deny send_destination="net.hadess.SensorProxy" send_interface="org.freedesktop.DBus.Properties" send_path="/net/hadess/SensorProxy/Compass"/>
+    <deny send_destination="net.hadess.SensorProxy" send_interface="org.freedesktop.DBus.Peer" send_path="/net/hadess/SensorProxy/Compass"/>
+    <!-- <deny send_destination="net.hadess.SensorProxy" send_interface="net.hadess.SensorProxy.Compass"/> -->
   </policy>
 
 </busconfig>


### PR DESCRIPTION
D-Bus policy XML files are generic configuration for the bus daemon:
they are conventionally named like a bus name, but there is nothing
that inherently limits their application to that bus name.

In particular this means that a rule like

    <policy context="default">
      <allow send_interface="org.freedesktop.DBus.Properties"/>

allows any process on the system bus to send an
org.freedesktop.DBus.Properties.Set() call to any other process on the
system bus, even if the destination process expected to be only
accessible by root.

Fixes https://github.com/hadess/iio-sensor-proxy/issues/41

---

This is untested so far. You might want to try it before merging and verify that you can still communicate with i-s-p in ways that ought to be allowed.

*edit: fix Markdown*