### PR TITLE
data: fix permissions when geoclue runs with a different user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 iio-sensor-proxy
+data/net.hadess.SensorProxy.conf

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,13 @@ AM_CONDITIONAL(HAVE_GTK_TESTS, test "x$enable_gtk_tests" = "xyes")
 
 PKG_CHECK_MODULES(IIO_SENSOR_PROXY, gio-2.0 gudev-1.0 >= 232)
 
+AC_ARG_WITH(geoclue-user,
+            AS_HELP_STRING([--with-geoclue-user=USER],
+                           [The USER (existing) as which geoclue service is running (default: geoclue)]),
+            geoclue_user="$with_geoclue_user",
+            geoclue_user="geoclue")
+AC_SUBST(geoclue_user)
+
 AC_PATH_PROG([GDBUS_CODEGEN],[gdbus-codegen])
 
 AC_CONFIG_FILES([

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -9,5 +9,9 @@ iio-sensor-proxy.service: iio-sensor-proxy.service.in Makefile
 dbusconfdir = $(sysconfdir)/dbus-1/system.d
 dbusconf_DATA = net.hadess.SensorProxy.conf
 
-CLEANFILES = iio-sensor-proxy.service
+net.hadess.SensorProxy.conf: net.hadess.SensorProxy.conf.in Makefile
+	@sed -e "s|\@geoclue_user\@|$(geoclue_user)|" $< > $@
+
+
+CLEANFILES = iio-sensor-proxy.service net.hadess.SensorProxy.conf
 EXTRA_DIST = $(udevrules_DATA) $(dbusconf_DATA) $(systemdservice_in_files)

--- a/data/net.hadess.SensorProxy.conf.in
+++ b/data/net.hadess.SensorProxy.conf.in
@@ -11,7 +11,7 @@
   </policy>
 
   <!-- Only Geoclue can access the compass -->
-  <policy user="geoclue">
+  <policy user="@geoclue_user@">
     <allow send_destination="net.hadess.SensorProxy" send_interface="net.hadess.SensorProxy.Compass" send_path="/net/hadess/SensorProxy/Compass"/>
     <allow send_destination="net.hadess.SensorProxy" send_interface="org.freedesktop.DBus.Introspectable" send_path="/net/hadess/SensorProxy/Compass"/>
     <allow send_destination="net.hadess.SensorProxy" send_interface="org.freedesktop.DBus.Properties" send_path="/net/hadess/SensorProxy/Compass"/>


### PR DESCRIPTION
Geoclue can be configured to use another user than geoclue.