### PR TITLE
Read mount matrix from sysfs

### DIFF
--- a/src/accel-mount-matrix.c
+++ b/src/accel-mount-matrix.c
@@ -24,6 +24,22 @@ static AccelVec3 id_matrix[3] = {
 
 static char axis_names[] = "xyz";
 
+AccelVec3 *
+setup_mount_matrix (GUdevDevice *device)
+{
+	AccelVec3 *ret = NULL;
+	const char *mount_matrix;
+
+	mount_matrix = g_udev_device_get_property (device, "ACCEL_MOUNT_MATRIX");
+	if (!parse_mount_matrix (mount_matrix, &ret)) {
+		g_warning ("Invalid mount-matrix ('%s'), falling back to identity",
+			   mount_matrix);
+		parse_mount_matrix (NULL, &ret);
+	}
+
+	return ret;
+}
+
 gboolean
 parse_mount_matrix (const char *mtx,
 		    AccelVec3  *vecs[3])

--- a/src/accel-mount-matrix.h
+++ b/src/accel-mount-matrix.h
@@ -8,12 +8,15 @@
  */
 
 #include <glib.h>
+#include <gudev/gudev.h>
 
 typedef struct {
 	float x;
 	float y;
 	float z;
 } AccelVec3;
+
+AccelVec3 *setup_mount_matrix (GUdevDevice *device);
 
 gboolean parse_mount_matrix (const char *mtx,
                              AccelVec3  *vecs[3]);

--- a/src/drv-iio-buffer-accel.c
+++ b/src/drv-iio-buffer-accel.c
@@ -200,7 +200,6 @@ iio_buffer_accel_open (GUdevDevice        *device,
 		       gpointer            user_data)
 {
 	char *trigger_name;
-	const char *mount_matrix;
 
 	drv_data = g_new0 (DrvData, 1);
 
@@ -218,13 +217,7 @@ iio_buffer_accel_open (GUdevDevice        *device,
 		return FALSE;
 	}
 
-	mount_matrix = g_udev_device_get_property (device, "ACCEL_MOUNT_MATRIX");
-	if (!parse_mount_matrix (mount_matrix, &drv_data->mount_matrix)) {
-		g_warning ("Invalid mount-matrix ('%s'), falling back to identity",
-			   mount_matrix);
-		parse_mount_matrix (NULL, &drv_data->mount_matrix);
-	}
-
+	drv_data->mount_matrix = setup_mount_matrix (device);
 	drv_data->dev = g_object_ref (device);
 	drv_data->dev_path = g_udev_device_get_device_file (device);
 	drv_data->name = g_udev_device_get_property (device, "NAME");

--- a/src/drv-iio-poll-accel.c
+++ b/src/drv-iio-poll-accel.c
@@ -118,21 +118,12 @@ iio_poll_accel_open (GUdevDevice        *device,
 		     ReadingsUpdateFunc  callback_func,
 		     gpointer            user_data)
 {
-	const char *mount_matrix;
-
 	iio_fixup_sampling_frequency (device);
 
 	drv_data = g_new0 (DrvData, 1);
 	drv_data->dev = g_object_ref (device);
 	drv_data->name = g_udev_device_get_sysfs_attr (device, "name");
-
-	mount_matrix = g_udev_device_get_property (device, "ACCEL_MOUNT_MATRIX");
-	if (!parse_mount_matrix (mount_matrix, &drv_data->mount_matrix)) {
-		g_warning ("Invalid mount-matrix ('%s'), falling back to identity",
-			   mount_matrix);
-		parse_mount_matrix (NULL, &drv_data->mount_matrix);
-	}
-
+	drv_data->mount_matrix = setup_mount_matrix (device);
 	drv_data->callback_func = callback_func;
 	drv_data->user_data = user_data;
 	drv_data->scale = g_udev_device_get_sysfs_attr_as_double (device, "in_accel_scale");

--- a/src/drv-input-accel.c
+++ b/src/drv-input-accel.c
@@ -192,7 +192,6 @@ input_accel_open (GUdevDevice        *device,
 		  gpointer            user_data)
 {
 	const gchar * const subsystems[] = { "input", NULL };
-	const char *mount_matrix;
 
 	drv_data = g_new0 (DrvData, 1);
 	drv_data->dev = g_object_ref (device);
@@ -202,14 +201,7 @@ input_accel_open (GUdevDevice        *device,
 	if (!drv_data->name)
 		drv_data->name = g_udev_device_get_property (device, "ID_MODEL");
 	drv_data->client = g_udev_client_new (subsystems);
-
-	mount_matrix = g_udev_device_get_property (device, "ACCEL_MOUNT_MATRIX");
-	if (!parse_mount_matrix (mount_matrix, &drv_data->mount_matrix)) {
-		g_warning ("Invalid mount-matrix ('%s'), falling back to identity",
-			   mount_matrix);
-		parse_mount_matrix (NULL, &drv_data->mount_matrix);
-	}
-
+	drv_data->mount_matrix = setup_mount_matrix (device);
 	drv_data->callback_func = callback_func;
 	drv_data->user_data = user_data;
 


### PR DESCRIPTION
If we don't have a ACCEL_MOUNT_MATRIX property for this device,
then check if there is a mount matrix available in sysfs.
Some kernel drivers export the mount matrix there, e.g. st_accel.

This fixes an issue where the screen was automatically rotated to
an incorrect orientation on Acer Veriton Z4660G/Z6860G/A890.