### PR TITLE
mount-matrix: also read mount-matrix from in_accel_mount_matrix

### DIFF
--- a/src/accel-mount-matrix.c
+++ b/src/accel-mount-matrix.c
@@ -40,6 +40,16 @@ setup_mount_matrix (GUdevDevice *device)
 		g_clear_pointer (&ret, g_free);
 	}
 
+	mount_matrix = g_udev_device_get_sysfs_attr (device, "in_accel_mount_matrix");
+	if (mount_matrix) {
+		if (parse_mount_matrix (mount_matrix, &ret))
+			return ret;
+
+		g_warning ("Failed to parse mount_matrix ('%s') from sysfs",
+			   mount_matrix);
+		g_clear_pointer (&ret, g_free);
+	}
+
 	mount_matrix = g_udev_device_get_sysfs_attr (device, "mount_matrix");
 	if (mount_matrix) {
 		if (parse_mount_matrix (mount_matrix, &ret))


### PR DESCRIPTION
The IIO framework may also export mount matrix with sysfs filename
in_accel_mount_matrix (when the type of this extinfo is set to be
IIO_SHARED_BY_TYPE.

Also try to read mount-matrix from this file.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>