### PR TITLE
Add support for ACCEL_LOCATION udev property to deal with 2 sensors

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,7 +37,7 @@ iio_sensor_proxy_CPPFLAGS =			\
 	$(WARN_CFLAGS)
 iio_sensor_proxy_LDADD = $(IIO_SENSOR_PROXY_LIBS) $(LIBM)
 
-noinst_PROGRAMS = fake-input-accelerometer test-mount-matrix test-orientation
+noinst_PROGRAMS = fake-input-accelerometer test-mount-matrix test-accel-location test-orientation
 
 fake_input_accelerometer_SOURCES =		\
 	fake-input-accelerometer.c		\
@@ -57,6 +57,16 @@ test_mount_matrix_CPPFLAGS =			\
 	$(IIO_SENSOR_PROXY_CFLAGS)		\
 	$(WARN_CFLAGS)
 test_mount_matrix_LDADD = $(IIO_SENSOR_PROXY_LIBS)
+
+test_accel_location_SOURCES =			\
+	test-accel-location.c			\
+	accel-location.h			\
+	accel-location.c
+
+test_accel_location_CPPFLAGS =			\
+	$(IIO_SENSOR_PROXY_CFLAGS)		\
+	$(WARN_CFLAGS)
+test_accel_location_LDADD = $(IIO_SENSOR_PROXY_LIBS)
 
 test_orientation_SOURCES =			\
 	test-orientation.c			\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,6 +28,8 @@ iio_sensor_proxy_SOURCES =			\
 	iio-buffer-utils.c			\
 	accel-mount-matrix.h			\
 	accel-mount-matrix.c			\
+	accel-location.h				\
+	accel-location.c				\
 	$(BUILT_SOURCES)
 
 iio_sensor_proxy_CPPFLAGS =			\

--- a/src/accel-location.c
+++ b/src/accel-location.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Luís Ferreira <luis@aurorafoss.org>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ */
+
+#include "accel-location.h"
+
+AccelLocation
+setup_accel_location (GUdevDevice *device)
+{
+	AccelLocation ret;
+	const char *location;
+
+	location = g_udev_device_get_property (device, "ACCEL_LOCATION");
+	if (location) {
+		if (parse_accel_location (location, &ret))
+			return ret;
+
+		g_warning ("Failed to parse ACCEL_LOCATION ('%s') from udev",
+			   location);
+	} else {
+		g_debug ("No autodetected location, falling back to display location");
+	}
+
+	ret = ACCEL_LOCATION_DISPLAY;
+	return ret;
+}
+
+gboolean
+parse_accel_location (const char *location, AccelLocation *value)
+{
+	/* Empty string means we use the display location */
+	if (location == NULL ||
+		*location == '\0' ||
+		(g_strcmp0 (location, "display") == 0)) {
+		*value = ACCEL_LOCATION_DISPLAY;
+		return TRUE;
+	} else if (g_strcmp0 (location, "base") == 0) {
+		*value = ACCEL_LOCATION_BASE;
+		return TRUE;
+	} else {
+		g_warning ("Failed to parse '%s' as a location", location);
+		return FALSE;
+	}
+}

--- a/src/accel-location.h
+++ b/src/accel-location.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019 Luís Ferreira <luis@aurorafoss.org>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ */
+
+#include <glib.h>
+#include <gudev/gudev.h>
+
+typedef enum {
+	ACCEL_LOCATION_DISPLAY,
+	ACCEL_LOCATION_BASE,
+} AccelLocation;
+
+AccelLocation setup_accel_location (GUdevDevice *device);
+
+gboolean parse_accel_location (const char    *location,
+                               AccelLocation *value);

--- a/src/drivers.h
+++ b/src/drivers.h
@@ -9,6 +9,8 @@
 #include <glib.h>
 #include <gudev/gudev.h>
 
+#include "accel-location.h"
+
 typedef enum {
 	DRIVER_TYPE_ACCEL,
 	DRIVER_TYPE_LIGHT,
@@ -77,7 +79,13 @@ driver_discover (SensorDriver *driver,
 	g_return_val_if_fail (driver->discover, FALSE);
 	g_return_val_if_fail (device, FALSE);
 
-	return driver->discover (device);
+	if (!driver->discover (device))
+		return FALSE;
+
+	if (driver->type != DRIVER_TYPE_ACCEL)
+		return TRUE;
+
+	return (setup_accel_location (device) == ACCEL_LOCATION_DISPLAY);
 }
 
 static inline gboolean

--- a/src/drv-iio-buffer-accel.c
+++ b/src/drv-iio-buffer-accel.c
@@ -24,6 +24,7 @@ typedef struct {
 	const char *dev_path;
 	const char *name;
 	AccelVec3 *mount_matrix;
+	AccelLocation location;
 	int device_id;
 	BufferDrvData *buffer_data;
 } DrvData;
@@ -218,6 +219,7 @@ iio_buffer_accel_open (GUdevDevice        *device,
 	}
 
 	drv_data->mount_matrix = setup_mount_matrix (device);
+	drv_data->location = setup_accel_location (device);
 	drv_data->dev = g_object_ref (device);
 	drv_data->dev_path = g_udev_device_get_device_file (device);
 	drv_data->name = g_udev_device_get_property (device, "NAME");

--- a/src/drv-iio-poll-accel.c
+++ b/src/drv-iio-poll-accel.c
@@ -24,6 +24,7 @@ typedef struct DrvData {
 	GUdevDevice        *dev;
 	const char         *name;
 	AccelVec3          *mount_matrix;
+	AccelLocation       location;
 
 	double              scale;
 } DrvData;
@@ -124,6 +125,7 @@ iio_poll_accel_open (GUdevDevice        *device,
 	drv_data->dev = g_object_ref (device);
 	drv_data->name = g_udev_device_get_sysfs_attr (device, "name");
 	drv_data->mount_matrix = setup_mount_matrix (device);
+	drv_data->location = setup_accel_location (device);
 	drv_data->callback_func = callback_func;
 	drv_data->user_data = user_data;
 	drv_data->scale = g_udev_device_get_sysfs_attr_as_double (device, "in_accel_scale");

--- a/src/drv-input-accel.c
+++ b/src/drv-input-accel.c
@@ -27,6 +27,7 @@ typedef struct DrvData {
 	const char *dev_path;
 	const char *name;
 	AccelVec3 *mount_matrix;
+	AccelLocation location;
 	gboolean sends_kevent;
 } DrvData;
 
@@ -202,6 +203,7 @@ input_accel_open (GUdevDevice        *device,
 		drv_data->name = g_udev_device_get_property (device, "ID_MODEL");
 	drv_data->client = g_udev_client_new (subsystems);
 	drv_data->mount_matrix = setup_mount_matrix (device);
+	drv_data->location = setup_accel_location (device);
 	drv_data->callback_func = callback_func;
 	drv_data->user_data = user_data;
 

--- a/src/test-accel-location.c
+++ b/src/test-accel-location.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019 Luís Ferreira <luis@aurorafoss.org>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ */
+
+#include "accel-location.h"
+
+#define VALID_DISPLAY_LOCATION "display"
+#define VALID_BASE_LOCATION "base"
+#define INVALID_LOCATION "invalid"
+
+static void
+test_accel_location (void)
+{
+	AccelLocation location;
+
+	/* display location */
+	g_assert_true (parse_accel_location (VALID_DISPLAY_LOCATION, &location));
+	g_assert_true (location == ACCEL_LOCATION_DISPLAY);
+
+	/* base location */
+	g_assert_true (parse_accel_location (VALID_BASE_LOCATION, &location));
+	g_assert_true (location == ACCEL_LOCATION_BASE);
+
+	/* default location (display) */
+	g_assert_true (parse_accel_location ("", &location));
+	g_assert_true (location == ACCEL_LOCATION_DISPLAY);
+
+	/* Invalid matrix */
+	g_test_expect_message (NULL, G_LOG_LEVEL_WARNING, "Failed to parse 'invalid' as a location");
+	g_assert_false (parse_accel_location (INVALID_LOCATION, &location));
+	g_test_assert_expected_messages ();
+}
+
+int main (int argc, char **argv)
+{
+	g_test_init (&argc, &argv, NULL);
+
+	g_test_add_func ("/iio-sensor-proxy/accel-location", test_accel_location);
+
+	return g_test_run ();
+}


### PR DESCRIPTION
This pull request fixes #166 .

As referred to in [this](https://lore.kernel.org/patchwork/patch/1057409/) kernel patch, `ACCEL_LOCATION` property should be added to udev.

---
Related issues and pull requests:
- [#6557](https://github.com/systemd/systemd/issues/6557) on systemd.
- [#12322](https://github.com/systemd/systemd/pull/12322) on systemd.