### PR TITLE
iio: Fix possible incorrect mask calculation

### DIFF
--- a/src/iio-buffer-utils.c
+++ b/src/iio-buffer-utils.c
@@ -136,9 +136,9 @@ iioutils_get_type (unsigned   *is_signed,
 	*be = (endianchar == 'b');
 	*bytes = padint / 8;
 	if (*bits_used == 64)
-		*mask = ~0;
+		*mask = ~G_GUINT64_CONSTANT(0);
 	else
-		*mask = (1 << *bits_used) - 1;
+		*mask = (G_GUINT64_CONSTANT(1) << *bits_used) - G_GUINT64_CONSTANT(1);
 	*is_signed = (signchar == 's');
 
 	g_debug ("Got type for %s: is signed: %d, bytes: %d, bits_used: %d, shift: %d, mask: 0x%" G_GUINT64_FORMAT ", be: %d",


### PR DESCRIPTION
On some machines, iio-sensor-proxy was returning all 0's for IIO sensor
values. It turns out that the bits_used for this sensor is 32, which makes
the mask calculation:

*mask = (1 << 32) - 1;

If the compiler interprets the 1 literals as 32-bit ints, it generates
undefined behavior depending on compiler version and optimization level.
On my system, it optimizes out the shift, so the mask value becomes

*mask = (1) - 1;

With a mask value of 0, iio-sensor-proxy will always return 0 for every axis.

Avoid incorrect 0 values caused by compiler optimization.

Closes: #270