### PR TITLE
Accelerometer: Get scale from sensors with IIO_SHARED_BY_ALL mask.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,8 +28,8 @@ iio_sensor_proxy_SOURCES =			\
 	iio-buffer-utils.c			\
 	accel-mount-matrix.h			\
 	accel-mount-matrix.c			\
-	accel-location.h				\
-	accel-location.c				\
+	accel-attributes.h				\
+	accel-attributes.c				\
 	$(BUILT_SOURCES)
 
 iio_sensor_proxy_CPPFLAGS =			\
@@ -63,8 +63,8 @@ test_mount_matrix_LDADD = $(IIO_SENSOR_PROXY_LIBS)
 
 test_accel_location_SOURCES =			\
 	test-accel-location.c			\
-	accel-location.h			\
-	accel-location.c
+	accel-attributes.h			\
+	accel-attributes.c
 
 test_accel_location_CPPFLAGS =			\
 	$(IIO_SENSOR_PROXY_CFLAGS)		\

--- a/src/accel-attributes.c
+++ b/src/accel-attributes.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Luís Ferreira <luis@aurorafoss.org>
+ * Copyright (c) 2019 Daniel Stuart <daniel.stuart@pucpr.edu.br>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3 as published by
@@ -7,7 +8,7 @@
  *
  */
 
-#include "accel-location.h"
+#include "accel-attributes.h"
 
 AccelLocation
 setup_accel_location (GUdevDevice *device)
@@ -54,4 +55,24 @@ parse_accel_location (const char *location, AccelLocation *value)
 		g_warning ("Failed to parse '%s' as a location", location);
 		return FALSE;
 	}
+}
+
+gdouble
+get_accel_scale (GUdevDevice *device)
+{
+	gdouble scale;
+
+	scale = g_udev_device_get_sysfs_attr_as_double (device, "in_accel_scale");
+	if (scale != 0.0) {
+		g_debug ("Attribute in_accel_scale ('%f') found on sysfs", scale);
+		return scale;
+	}
+	scale = g_udev_device_get_sysfs_attr_as_double (device, "scale");
+	if (scale != 0.0) {
+		g_debug ("Attribute scale ('%f') found on sysfs", scale);
+		return scale;
+	}
+
+	g_debug ("Failed to auto-detect scale, falling back to 1.0");
+	return 1.0;
 }

--- a/src/accel-attributes.h
+++ b/src/accel-attributes.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Luís Ferreira <luis@aurorafoss.org>
+ * Copyright (c) 2019 Daniel Stuart <daniel.stuart@pucpr.edu.br>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3 as published by
@@ -19,3 +20,5 @@ AccelLocation setup_accel_location (GUdevDevice *device);
 
 gboolean parse_accel_location (const char    *location,
                                AccelLocation *value);
+
+gdouble get_accel_scale (GUdevDevice *device);

--- a/src/drivers.h
+++ b/src/drivers.h
@@ -9,7 +9,7 @@
 #include <glib.h>
 #include <gudev/gudev.h>
 
-#include "accel-location.h"
+#include "accel-attributes.h"
 
 typedef enum {
 	DRIVER_TYPE_ACCEL,

--- a/src/drv-iio-poll-accel.c
+++ b/src/drv-iio-poll-accel.c
@@ -25,8 +25,7 @@ typedef struct DrvData {
 	const char         *name;
 	AccelVec3          *mount_matrix;
 	AccelLocation       location;
-
-	double              scale;
+	gdouble             scale;
 } DrvData;
 
 static DrvData *drv_data = NULL;
@@ -128,9 +127,7 @@ iio_poll_accel_open (GUdevDevice        *device,
 	drv_data->location = setup_accel_location (device);
 	drv_data->callback_func = callback_func;
 	drv_data->user_data = user_data;
-	drv_data->scale = g_udev_device_get_sysfs_attr_as_double (device, "in_accel_scale");
-	if (drv_data->scale == 0.0)
-		drv_data->scale = 1.0;
+	drv_data->scale = get_accel_scale (device);
 
 	return TRUE;
 }

--- a/src/test-accel-location.c
+++ b/src/test-accel-location.c
@@ -7,7 +7,7 @@
  *
  */
 
-#include "accel-location.h"
+#include "accel-attributes.h"
 
 #define VALID_DISPLAY_LOCATION "display"
 #define VALID_BASE_LOCATION "base"


### PR DESCRIPTION
Properties with IIO_SHARED_BY_ALL mask don't have the sensor type prefix before
the file identifier, this caused some devices to not use the scale from sysfs.

As so, it is fixed by searching through sysfs for both properties: scale and
in_accel_scale.

This commit is based on f14d26d1 [accel-location: add helper functions for
ACCEL_LOCATION udev property].