### PR TITLE
light: Support sensors using raw values as well

### DIFF
--- a/data/80-iio-sensor-proxy.rules
+++ b/data/80-iio-sensor-proxy.rules
@@ -9,6 +9,7 @@ SUBSYSTEM=="iio", TEST=="in_accel_x_raw", TEST=="in_accel_y_raw", TEST=="in_acce
 SUBSYSTEM=="iio", TEST=="scan_elements/in_accel_x_en", TEST=="scan_elements/in_accel_y_en", TEST=="scan_elements/in_accel_z_en", ENV{IIO_SENSOR_PROXY_TYPE}="iio-buffer-accel"
 SUBSYSTEM=="iio", TEST=="scan_elements/in_rot_from_north_magnetic_tilt_comp_en", ENV{IIO_SENSOR_PROXY_TYPE}="iio-buffer-compass"
 SUBSYSTEM=="iio", TEST=="in_illuminance_input", ENV{IIO_SENSOR_PROXY_TYPE}="iio-poll-als"
+SUBSYSTEM=="iio", TEST=="in_illuminance_raw", ENV{IIO_SENSOR_PROXY_TYPE}="iio-poll-als"
 SUBSYSTEM=="iio", TEST=="scan_elements/in_intensity_both_en", ENV{IIO_SENSOR_PROXY_TYPE}="iio-buffer-als"
 SUBSYSTEM=="input", ENV{ID_INPUT_ACCELEROMETER}=="1", ENV{IIO_SENSOR_PROXY_TYPE}="input-accel"
 


### PR DESCRIPTION
E.g. the vcnl4000 class devices reports a raw value and a scale
to calculate lux.